### PR TITLE
2.6.3 work.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+v 2.6.3
+ * Deprecated `priority` in plugins.
+ * Made `setTimestampFunction`, `set`, `addPlugin`, `removePlugin` in Yolog return `this` (fluent).
+ * Made `set` in Plugin return `this` (fluent).
+
 v 2.6.0
  * Introduced a new parameter (error) for plugins.
  * Introduced new property (errorObject) on event.

--- a/README.md
+++ b/README.md
@@ -71,19 +71,19 @@ logger.debug('Weee!')
 
 ### Log tags
 
-The Yolog class have a set of pre-defined tags which are used to output different type of loggs with. It is possible to turn a 
+The Yolog class have a set of pre-defined tags which are used to output different type of logs with. It is possible to turn a 
 tag on and off via code, both in a plugin or in the Yolog instance itself.  
 The pre-defined tags are (name and default value):
 
 ```json
 {
-    "debug": true,
-    "info": true,
-    "warning": true,
-    "error": true,
-    "critical": true,
-    "alert": true,
-    "emergency": true
+  "debug": true,
+  "info": true,
+  "warning": true,
+  "error": true,
+  "critical": true,
+  "alert": true,
+  "emergency": true
 }
 ```
 
@@ -196,7 +196,9 @@ Community developed plugins listed here are not under the control of Jitesoft an
 is nothing that Jitesoft can be held liable for. As with everything, you should always audit the code you use before
 using it in production!
 
-## Base API
+## More docs!
+
+### Yolog
 
 The Yolog base API is quite simple, there are a few methods to customize the logger, while most of the configurations should
 be done in plugins.  
@@ -208,9 +210,9 @@ are the following:
 
 ```typescript
 interface Yolog {
-    on(tag: string, handler: Function, priority: number): number;
-    off(tag: string, handler: number | Function): boolean;
-    once(tag: string, handler: Function, priority?: number): number;
+  on(tag: string, handler: Function, priority: number): number;
+  off(tag: string, handler: number | Function): boolean;
+  once(tag: string, handler: Function, priority?: number): number;
 }
 ```
 
@@ -232,9 +234,9 @@ used for this:
 
 ```typescript
 interface Yolog {
-    addPlugin(plugin: Plugin): Yolog;
-    removePlugin(plugin: Plugin): Yolog;
-    readonly plugins: Plugin[];
+  addPlugin(plugin: Plugin): Yolog;
+  removePlugin(plugin: Plugin): Yolog;
+  readonly plugins: Plugin[];
 }
 ```
 
@@ -249,7 +251,7 @@ Tags is quite an important thing in yolog (and most logging...), there are a few
 that are used to invoke those. The predefined tags are:
 
 ```javascript
-[
+const tags = [
   'debug',
   'info',
   'warning',
@@ -257,7 +259,7 @@ that are used to invoke those. The predefined tags are:
   'critical',
   'alert',
   'emergency'
-]
+];
 ```
 
 You may call a specific log tag via the `tagName(message: string, ...args): Promise<void>` methods, and if you wish to use
@@ -266,8 +268,8 @@ Just make sure that the tag exists in the logger by adding it in the `set` metho
 
 ```typescript
 interface Yolog {
-    set(tag: string, state?: boolean): Yolog;
-    get(tag: string): boolean;
+  set(tag: string, state?: boolean): Yolog;
+  get(tag: string): boolean;
 }
 ```
 
@@ -292,13 +294,52 @@ lists of strings (the name of the tag) and are readonly:
 
 ```typescript
 interface Yolog {
-    readonly available: string[];
-    readonly active: string[];
+  readonly available: string[];
+  readonly active: string[];
 }
 ```
 
 The `available` getter will return the names of all tags that are set in yolog, this includes all custom tags you have created.
 The `active` getter will return the names of all the tags that have state set to `true`.
+
+### Plugin
+
+Just as with the base API, the plugins have their own `tags` to turn off and on! This is to make it possible to have specific 
+loggin types on for some tags while others are not. For example: you might want to output `debug` to console and 
+you wish to use an email plugin for the `critical` logs.  
+If it was not possible to turn off most tags for the email plugin, you would receive a new email for each debug log made. 
+
+**Active and available**
+
+The `available` and `active` getters works as with the yolog class, the first returns all tags that are available in the plugin,
+the `active` returns which are turned on.
+
+```typescript
+interface Plugin {
+  readonly available: string[];
+  readonly active: string[];
+}
+```
+
+**Set and Get**
+
+The set and get methods are - just as with the Yolog class - used to turn tags on and off and to check if a given tag is on or off.   
+Calling `set` will create a new tag if none exist, else update it.  
+
+**log**
+
+The log method is the most important function of the Plugins. It is basically the only method that is required to be implemented to create a new plugin.
+`log` is an async method which takes a tag, timestamp, message and error. The message is the formatted message that Yolog passes
+to all plugins. The tag is the tag that was used when the log call was made. Timestamp is intended to be a Unix timestamp, which
+can be used inside the plugin to format a nice time string for output.  
+
+Since v 2.6.0 a new `Error` argument is passed as the last argument of the log method. It can be used to output the callstack or similar
+information.
+
+**Priority**
+
+The `priority` getter and setter have been deprecated since v 2.6.3 and will be removed in v 3.x. It has no usage as of now, due to the
+fact that Yolog calls all the plugins asynchronously (making priority nil).
 
 ## Notes
 
@@ -321,3 +362,11 @@ logger - by Johannes at Talkative Labs - just to add colours to console logs. So
 After the initial release, the work on the package went stale for quite a while, like... years!  
 It was finally picked up again in 2018 and rebuilt and re-branded as `yolog` under the `@jitesoft` org. The new version was not only for colourful
 console outputs, but rather a small plugin system for logging with a basic API which was easy to use and extend.  
+
+### Development & Contributions
+
+Contributions in any form are very welcome!   
+Issues (bugs, feature requests, questions etc etc) can be posted in the [GitHub issue tracker](https://github.com/jitesoft/yolog/issues).  
+Pull requests will be reviewed and should contain tests and follow the code style.
+
+If you wish to contribute by monetary means, feel free to click the `sponsor` button on GitHub or head on over to our [OpenCollective](https://opencollective.com/jitesoft-open-source) page!

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ The source can be found at [GitHub](https://github.com/jitesoft/yolog) and [GitL
 
 ### Tiny bit of history, cause why not?
 
-First release of `yolog` (back then under the name of `node-yolog`) was back in 2013, so quite a while ago... It was developed as a tiny in-house
+First release of `yolog` (back then under the name of `node-yolog`) was back in 2014, so quite a while ago... It was developed as a tiny in-house
 logger - by Johannes at Talkative Labs - just to add colours to console logs. So nothing great nor special, although it did make the console look better!  
 After the initial release, the work on the package went stale for quite a while, like... years!  
 It was finally picked up again in 2018 and rebuilt and re-branded as `yolog` under the `@jitesoft` org. The new version was not only for colourful
@@ -370,3 +370,29 @@ Issues (bugs, feature requests, questions etc etc) can be posted in the [GitHub 
 Pull requests will be reviewed and should contain tests and follow the code style.
 
 If you wish to contribute by monetary means, feel free to click the `sponsor` button on GitHub or head on over to our [OpenCollective](https://opencollective.com/jitesoft-open-source) page!
+
+#### License
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2019 Johannes Tegnér / Jitesoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/README.md
+++ b/README.md
@@ -208,6 +208,6 @@ Community developed plugins listed here are not under the control of Jitesoft an
 is nothing that Jitesoft can be held liable for. As with everything, you should always audit the code you use before
 using it in production!
 
-### Source code
+#### Source code
 
 The source can be found at [GitHub](https://github.com/jitesoft/yolog) and [GitLab](https://gitlab.com/jitesoft/open-source/javascript/yolog).

--- a/README.md
+++ b/README.md
@@ -176,17 +176,7 @@ interface PluginInterface {
 
 To add a new plugin to the Yolog instance, call the `addPlugin(plugin)` method, removal can be done with `removePlugin(plugin)`.
 
-### Notes
-
-Any undocumented features are either in development or working as intended but not yet fully tested or documented. Use with care.
-
-### Versioning.
-
-Yolog follows the [Semantic Versioning 2.0.0](http://semver.org/)  
-This basically means that no API breaking changes will occur without a new major version release, features might be added
-during a minor release and patches are only fixes.
-
-## Official plugins
+### Official plugins
 
 The following list are plugins maintained and supported by Jitesoft.
 
@@ -197,22 +187,134 @@ The following list are plugins maintained and supported by Jitesoft.
 
 _More are under development._
 
-## Community developed plugins
+### Community developed plugins
 
 _Create a pull request for the readme file to include your plugin here (after a general audit)!_
-
----
 
 **Observe:**  
 Community developed plugins listed here are not under the control of Jitesoft and any damages they may or may not cause
 is nothing that Jitesoft can be held liable for. As with everything, you should always audit the code you use before
 using it in production!
 
-#### Source code
+## Base API
+
+The Yolog base API is quite simple, there are a few methods to customize the logger, while most of the configurations should
+be done in plugins.  
+
+**Events**
+
+As mentioned above, the Yolog instance can be used as an event handler, the methods connected to this features
+are the following:
+
+```typescript
+interface Yolog {
+    on(tag: string, handler: Function, priority: number): number;
+    off(tag: string, handler: number | Function): boolean;
+    once(tag: string, handler: Function, priority?: number): number;
+}
+```
+
+The methods pretty much speak for themselves. On and Once both returns a number, the number
+is the handle of the specific handler function. If the handler is to be removed, the handle 
+or the function itself can be passed to yolog through the `off` method, removing it from the list of handlers.
+
+Priority is a batch priority, that is, if multiple handlers have the same priority, they will be called
+async at the same time. If either of them returns false, the event will not bubble to the next batch.  
+There is currently no built in way to not allow other handlers with the same priority to stop each other.
+
+Events start their emit before the plugins are invoked, but yolog will not wait for them to finnish before starting
+to run the plugins. That way, you can not be sure that the plugins are invoked before the plugins, or the other way around.
+
+**Plugins**
+
+Adding and removing plugins is if possible more easy than using the events. The following methods are
+used for this:
+
+```typescript
+interface Yolog {
+    addPlugin(plugin: Plugin): Yolog;
+    removePlugin(plugin: Plugin): Yolog;
+    readonly plugins: Plugin[];
+}
+```
+
+Plugins are all called in batch when a log command is done, they have no priority over each other and 
+the promise of the log method called will resolve when all are done.
+
+The getter `plugins` will return all the plugins that are loaded in the instance.
+
+**Tags**
+
+Tags is quite an important thing in yolog (and most logging...), there are a few pre-defined tags and methods
+that are used to invoke those. The predefined tags are:
+
+```javascript
+[
+  'debug',
+  'info',
+  'warning',
+  'error',
+  'critical',
+  'alert',
+  'emergency'
+]
+```
+
+You may call a specific log tag via the `tagName(message: string, ...args): Promise<void>` methods, and if you wish to use
+a custom tag, the `custom(tag: string, message: string, ...args): Promise<void>` method is available.  
+Just make sure that the tag exists in the logger by adding it in the `set` method!
+
+```typescript
+interface Yolog {
+    set(tag: string, state?: boolean): Yolog;
+    get(tag: string): boolean;
+}
+```
+
+The `set` method adds a tag or updates existing tags states, if it's set to `true` the tag will be available in yolog, if false, it will not
+this way you can globally configure some tags to be on or off, if they are off, no event nor plugin will be invoked when the
+method is used.  
+`get` will return `true` or `false` depending on the state of the tag.
+
+An example of where this can be a useful feature is when you wish to use environment specific tags:
+
+```javascript
+if (process.env.NODE_ENV === 'production') {
+  yolog.set('debug', false);
+  yolog.set('emergency', true);
+}
+```
+
+**Active and available**
+
+There are two getters which can be used to get information about active and available tags, they both return
+lists of strings (the name of the tag) and are readonly:
+
+```typescript
+interface Yolog {
+    readonly available: string[];
+    readonly active: string[];
+}
+```
+
+The `available` getter will return the names of all tags that are set in yolog, this includes all custom tags you have created.
+The `active` getter will return the names of all the tags that have state set to `true`.
+
+## Notes
+
+Any undocumented features are either in development or working as intended but not yet fully tested or documented. Use with care.
+
+### Versioning.
+
+Yolog follows the [Semantic Versioning 2.0.0](http://semver.org/)  
+This basically means that no API breaking changes will occur without a new major version release, features might be added
+during a minor release and patches are only fixes.
+
+### Source code
 
 The source can be found at [GitHub](https://github.com/jitesoft/yolog) and [GitLab](https://gitlab.com/jitesoft/open-source/javascript/yolog).
 
-#### Tiny bit of history, cause why not?
+### Tiny bit of history, cause why not?
 
 First release of `yolog` (back then under the name of `node-yolog`) was back in 2013, so quite a while ago... It was developed as a tiny in-house
 logger - by Johannes at Talkative Labs - just to add colours to console logs. So nothing great nor special, although it did make the console look better!  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1620,24 +1620,24 @@
             }
         },
         "@jitesoft/eslint-config": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@jitesoft/eslint-config/-/eslint-config-1.7.1.tgz",
-            "integrity": "sha512-qb+fOk8+onNXFhI96aemOMiV+L9FOsYJGCH13k/LQU6BmeBLGijdVq+muy5NiS9DjE8JgarHJeXfyW8eBXkzPg==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@jitesoft/eslint-config/-/eslint-config-1.7.2.tgz",
+            "integrity": "sha512-w3+5aHp7zKAl6EoefjId57RBLiqT3A5wRvAdZ4ZNFWLa9MApiJtT9kqBMrplScOWZIn8b1QMFguoC7iS1rZEbg==",
             "dev": true,
             "requires": {
                 "eslint-config-standard": "14.1.0",
                 "eslint-plugin-es": "2.0.0",
                 "eslint-plugin-import": "2.18.2",
-                "eslint-plugin-jest": "22.19.0",
+                "eslint-plugin-jest": "23.0.2",
                 "eslint-plugin-node": "10.0.0",
                 "eslint-plugin-promise": "4.2.1",
                 "eslint-plugin-standard": "4.0.1"
             }
         },
         "@jitesoft/events": {
-            "version": "1.3.11",
-            "resolved": "https://registry.npmjs.org/@jitesoft/events/-/events-1.3.11.tgz",
-            "integrity": "sha512-SMLorQSBQPeRt/IMOAF/mFdH7DsuWiZwSPh1GHbH4VPbC0IsAnHSt11QR1KDHCgiU2tkS5n+VDDW3taruZeuAQ==",
+            "version": "1.3.12",
+            "resolved": "https://registry.npmjs.org/@jitesoft/events/-/events-1.3.12.tgz",
+            "integrity": "sha512-LUnu7Hx2o05+OOso6YeYMb/yUkcXdVK4qTHQjBBpNE6kWND58yWOdAqQjPnUtjZNkLjMB02plk33RzksEtcqvg==",
             "requires": {
                 "@babel/runtime-corejs3": "^7.6.3",
                 "@jitesoft/group-by": "^1.1.10"
@@ -1747,30 +1747,45 @@
             "dev": true
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-            "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.0.tgz",
+            "integrity": "sha512-34BAFpNOwHXeqT+AvdalLxOvcPYnCxA5JGmBAFL64RGMdP0u65rXjii7l/nwpgk5aLEE1LaqF+SsCU0/Cb64xA==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/typescript-estree": "1.13.0",
-                "eslint-scope": "^4.0.0"
+                "@typescript-eslint/typescript-estree": "2.6.0",
+                "eslint-scope": "^5.0.0"
+            },
+            "dependencies": {
+                "eslint-scope": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+                    "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                }
             }
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-            "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.0.tgz",
+            "integrity": "sha512-A3lSBVIdj2Gp0lFEL6in2eSPqJ33uAc3Ko+Y4brhjkxzjbzLnwBH22CwsW2sCo+iwogfIyvb56/AJri15H0u5Q==",
             "dev": true,
             "requires": {
+                "debug": "^4.1.1",
+                "glob": "^7.1.4",
+                "is-glob": "^4.0.1",
                 "lodash.unescape": "4.0.1",
-                "semver": "5.5.0"
+                "semver": "^6.3.0"
             },
             "dependencies": {
                 "semver": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 }
             }
@@ -3008,9 +3023,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-            "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.6.tgz",
+            "integrity": "sha512-u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA==",
             "dev": true
         },
         "core-js-compat": {
@@ -3722,12 +3737,12 @@
             }
         },
         "eslint-plugin-jest": {
-            "version": "22.19.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.19.0.tgz",
-            "integrity": "sha512-4zUc3rh36ds0SXdl2LywT4YWA3zRe8sfLhz8bPp8qQPIKvynTTkNGwmSCMpl5d9QiZE2JxSinGF+WD8yU+O0Lg==",
+            "version": "23.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.0.2.tgz",
+            "integrity": "sha512-fkxcvOJm0hC/jbJqYJjtuC9mvpTJqXd0Nixx7joVQvJoBQuXk/ws3+MtRYzD/4TcKSgvr21uuSLdwSxKJKC2cg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "^1.13.0"
+                "@typescript-eslint/experimental-utils": "^2.5.0"
             }
         },
         "eslint-plugin-node": {

--- a/package.json
+++ b/package.json
@@ -40,18 +40,18 @@
         ]
     },
     "dependencies": {
-        "@jitesoft/events": "^1.3.11",
+        "@jitesoft/events": "^1.3.12",
         "@jitesoft/sprintf": "^1.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.6.4",
         "@babel/runtime-corejs3": "^7.6.3",
         "@jitesoft/babel-preset-main": "^1.6.3",
-        "@jitesoft/eslint-config": "^1.7.1",
+        "@jitesoft/eslint-config": "^1.7.2",
         "babel-eslint": "^10.0.3",
         "babel-jest": "^24.9.0",
         "babel-loader": "^8.0.6",
-        "core-js": "^3.3.5",
+        "core-js": "^3.3.6",
         "cross-env": "^6.0.3",
         "eslint": "^6.6.0",
         "jest": "^24.9.0",

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -8,6 +8,7 @@ export default class Plugin {
     return this.#id;
   }
 
+  /** @deprecated */
   #priority = 0;
 
   #tags = {
@@ -78,6 +79,7 @@ export default class Plugin {
    * Setter for plugin priority, depending on priority it will be invoked before or after other plugins.
    *
    * @param value
+   * @deprecated
    */
   set priority (value) {
     this.#priority = value;
@@ -87,6 +89,7 @@ export default class Plugin {
    * Getter to fetch the plugin priority, depending on priority, it will be invoked before or after other plugins.
    *
    * @return {Number}
+   * @deprecated
    */
   get priority () {
     return this.#priority;

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -42,9 +42,11 @@ export default class Plugin {
    *
    * @param {String} tag
    * @param {Boolean} [state]
+   * @return {Plugin} Self.
    */
   set (tag, state = null) {
     this.#tags[tag.toLowerCase()] = state !== null ? state : !this.get(tag);
+    return this;
   }
 
   /**

--- a/src/Yolog.js
+++ b/src/Yolog.js
@@ -70,9 +70,11 @@ export default class Yolog {
    * Defaults to `() => { return (new Date()).getTime() };`
    *
    * @param {Function} func Function to use.
+   * @return {Yolog} Self.
    */
   setTimestampFunction (func) {
     this.#timestamp = func;
+    return this;
   }
 
   /**
@@ -99,9 +101,11 @@ export default class Yolog {
    *
    * @param {String} tag Tag name.
    * @param {Boolean} [state] State to set the tag to.
+   * @return {Yolog} self
    */
   set (tag, state = null) {
     this.#tags[tag.toLowerCase()] = state !== null ? state : !this.get(tag);
+    return this;
   }
 
   /**
@@ -127,22 +131,26 @@ export default class Yolog {
    * Add a plugin to the current Yolog instance.
    *
    * @param {Plugin} plugin
+   * @return {Yolog} self
    */
   addPlugin (plugin) {
     this.#plugins.push(plugin);
     this.#plugins.sort((p, p2) => p.priority - p2.priority);
+    return this;
   }
 
   /**
    * Remove a plugin from current Yolog instance.
    *
    * @param {Plugin} plugin
+   * @return {Yolog} self
    */
   removePlugin (plugin) {
     const index = this.#plugins.findIndex((p) => p.id === plugin.id);
     if (index !== -1) {
       this.#plugins.splice(index, 1);
     }
+    return this;
   }
 
   #log = async (tag, message, ...args) => {


### PR DESCRIPTION
Minor updates to the api which are none-breaking.
Updated CHANGES.md file with full changelog.

In short: some methods are now fluent (returns `this`) to allow chaining method calls.  
Deprecation of the `priority` property in the Plugin class.  
Updated documentation.