### PR TITLE
Updated to latest packages. Events 2.0.0 (changed emitasync to emit).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.4.tgz",
-            "integrity": "sha512-t+rjExOrSVvjQQXNp5zAIYDp00KjdvGl/TpDX5REPr0S9IAIPQMTilcfG6q8c0QFmj9lSTVySV2VTsyggvtNIw==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
+            "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.12.0",
@@ -24,38 +24,37 @@
             }
         },
         "@babel/core": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.4.tgz",
-            "integrity": "sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==",
+            "version": "7.11.1",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
+            "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/generator": "^7.11.0",
+                "@babel/helper-module-transforms": "^7.11.0",
                 "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.10.4",
+                "@babel/parser": "^7.11.1",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4",
+                "@babel/traverse": "^7.11.0",
+                "@babel/types": "^7.11.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
                 "json5": "^2.1.2",
-                "lodash": "^4.17.13",
+                "lodash": "^4.17.19",
                 "resolve": "^1.3.2",
                 "semver": "^5.4.1",
                 "source-map": "^0.5.0"
             }
         },
         "@babel/generator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-            "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+            "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.4",
+                "@babel/types": "^7.11.0",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
@@ -92,13 +91,13 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.4.tgz",
-            "integrity": "sha512-9raUiOsXPxzzLjCXeosApJItoMnX3uyT4QdM2UldffuGApNrF8e938MwNpDCK9CPoyxrEoCgT+hObJc3mZa6lQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+            "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
             "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-member-expression-to-functions": "^7.10.5",
                 "@babel/helper-optimise-call-expression": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/helper-replace-supers": "^7.10.4",
@@ -117,14 +116,14 @@
             }
         },
         "@babel/helper-define-map": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.4.tgz",
-            "integrity": "sha512-nIij0oKErfCnLUCWaCaHW0Bmtl2RO9cN7+u2QT8yqTywgALKlyUVOvHDElh+b5DwVC6YB1FOYFOTWcN/+41EDA==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+            "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "lodash": "^4.17.13"
+                "@babel/types": "^7.10.5",
+                "lodash": "^4.17.19"
             }
         },
         "@babel/helper-explode-assignable-expression": {
@@ -167,12 +166,12 @@
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-            "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+            "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.11.0"
             }
         },
         "@babel/helper-module-imports": {
@@ -185,18 +184,18 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-            "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+            "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.10.4",
                 "@babel/helper-replace-supers": "^7.10.4",
                 "@babel/helper-simple-access": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
                 "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "lodash": "^4.17.13"
+                "@babel/types": "^7.11.0",
+                "lodash": "^4.17.19"
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -215,12 +214,12 @@
             "dev": true
         },
         "@babel/helper-regex": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.4.tgz",
-            "integrity": "sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+            "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.13"
+                "lodash": "^4.17.19"
             }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -258,13 +257,22 @@
                 "@babel/types": "^7.10.4"
             }
         },
-        "@babel/helper-split-export-declaration": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-            "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+        "@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
+            "integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.11.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+            "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.11.0"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -308,15 +316,15 @@
             }
         },
         "@babel/parser": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-            "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
+            "version": "7.11.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
+            "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==",
             "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.4.tgz",
-            "integrity": "sha512-MJbxGSmejEFVOANAezdO39SObkURO5o/8b6fSH6D1pi9RZQt+ldppKPXfqgUWpSQ9asM6xaSaSJIaeWMDRP0Zg==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+            "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
@@ -335,12 +343,12 @@
             }
         },
         "@babel/plugin-proposal-decorators": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.10.4.tgz",
-            "integrity": "sha512-JHTWjQngOPv+ZQQqOGv2x6sCCr4IYWy7S1/VH6BE9ZfkoLrdQ2GpEP3tfb5M++G9PwvqjhY8VC/C3tXm+/eHvA==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.10.5.tgz",
+            "integrity": "sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.4",
+                "@babel/helper-create-class-features-plugin": "^7.10.5",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-decorators": "^7.10.4"
             }
@@ -385,6 +393,16 @@
                 "@babel/plugin-syntax-json-strings": "^7.8.0"
             }
         },
+        "@babel/plugin-proposal-logical-assignment-operators": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
+            "integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+            }
+        },
         "@babel/plugin-proposal-nullish-coalescing-operator": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
@@ -406,9 +424,9 @@
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-            "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+            "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
@@ -427,19 +445,20 @@
             }
         },
         "@babel/plugin-proposal-optional-chaining": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz",
-            "integrity": "sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
+            "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-partial-application": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-partial-application/-/plugin-proposal-partial-application-7.10.4.tgz",
-            "integrity": "sha512-efAk2LsWqqHICchyCrPjchcHMU6/3PTyL9Fs5ASb3mtESoElZ5gjM45RoVLOHR36bIzoy1sBtjI4SHmXw/APUg==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-partial-application/-/plugin-proposal-partial-application-7.10.5.tgz",
+            "integrity": "sha512-jHUbIZafbJO+y9SHyeBMsEqhkkIxBAR4wvPMX7y9scV+xGhq1NuQQxnFQdKtKL43W9RN6gk+gSybVtqBIvREqg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
@@ -668,13 +687,12 @@
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.4.tgz",
-            "integrity": "sha512-J3b5CluMg3hPUii2onJDRiaVbPtKFPLEaV5dOPY5OeAbDi1iU/UbbFFTgwb7WnanaDy7bjU35kc26W3eM5Qa0A==",
+            "version": "7.11.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
+            "integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "lodash": "^4.17.13"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-classes": {
@@ -778,12 +796,12 @@
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.4.tgz",
-            "integrity": "sha512-3Fw+H3WLUrTlzi3zMiZWp3AR4xadAEMv6XRCYnd5jAlLM61Rn+CRJaZMaNvIpcJpQ3vs1kyifYvEVPFfoSkKOA==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+            "integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.10.5",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
             }
@@ -801,13 +819,13 @@
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.4.tgz",
-            "integrity": "sha512-Tb28LlfxrTiOTGtZFsvkjpyjCl9IoaRI52AEU/VIwOwvDQWtbNJsAqTXzh+5R7i74e/OZHH2c2w2fsOqAfnQYQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+            "integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
             "dev": true,
             "requires": {
                 "@babel/helper-hoist-variables": "^7.10.4",
-                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.10.5",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
             }
@@ -860,9 +878,9 @@
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.4.tgz",
-            "integrity": "sha512-RurVtZ/D5nYfEg0iVERXYKEgDFeesHrHfx8RT05Sq57ucj2eOYAP6eu5fynL4Adju4I/mP/I6SO0DqNWAXjfLQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+            "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
             "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.10.4",
@@ -897,9 +915,9 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.4.tgz",
-            "integrity": "sha512-8ULlGv8p+Vuxu+kz2Y1dk6MYS2b/Dki+NO6/0ZlfSj5tMalfDL7jI/o/2a+rrWLqSXvnadEqc2WguB4gdQIxZw==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
+            "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.10.4",
@@ -918,12 +936,13 @@
             }
         },
         "@babel/plugin-transform-spread": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.4.tgz",
-            "integrity": "sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
+            "integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
@@ -937,9 +956,9 @@
             }
         },
         "@babel/plugin-transform-template-literals": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.4.tgz",
-            "integrity": "sha512-4NErciJkAYe+xI5cqfS8pV/0ntlY5N5Ske/4ImxAVX7mk9Rxt2bwDTGv1Msc2BRJvWQcmYEC+yoMLdX22aE4VQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+            "integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
@@ -975,30 +994,34 @@
             }
         },
         "@babel/preset-env": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.4.tgz",
-            "integrity": "sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
+            "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.10.4",
+                "@babel/compat-data": "^7.11.0",
                 "@babel/helper-compilation-targets": "^7.10.4",
                 "@babel/helper-module-imports": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
                 "@babel/plugin-proposal-class-properties": "^7.10.4",
                 "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+                "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
                 "@babel/plugin-proposal-json-strings": "^7.10.4",
+                "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
                 "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
                 "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-                "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
+                "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
                 "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-                "@babel/plugin-proposal-optional-chaining": "^7.10.4",
+                "@babel/plugin-proposal-optional-chaining": "^7.11.0",
                 "@babel/plugin-proposal-private-methods": "^7.10.4",
                 "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
                 "@babel/plugin-syntax-async-generators": "^7.8.0",
                 "@babel/plugin-syntax-class-properties": "^7.10.4",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
                 "@babel/plugin-syntax-json-strings": "^7.8.0",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
                 "@babel/plugin-syntax-numeric-separator": "^7.10.4",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
@@ -1031,14 +1054,14 @@
                 "@babel/plugin-transform-regenerator": "^7.10.4",
                 "@babel/plugin-transform-reserved-words": "^7.10.4",
                 "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-                "@babel/plugin-transform-spread": "^7.10.4",
+                "@babel/plugin-transform-spread": "^7.11.0",
                 "@babel/plugin-transform-sticky-regex": "^7.10.4",
                 "@babel/plugin-transform-template-literals": "^7.10.4",
                 "@babel/plugin-transform-typeof-symbol": "^7.10.4",
                 "@babel/plugin-transform-unicode-escapes": "^7.10.4",
                 "@babel/plugin-transform-unicode-regex": "^7.10.4",
                 "@babel/preset-modules": "^0.1.3",
-                "@babel/types": "^7.10.4",
+                "@babel/types": "^7.11.0",
                 "browserslist": "^4.12.0",
                 "core-js-compat": "^3.6.2",
                 "invariant": "^2.2.2",
@@ -1060,18 +1083,18 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
-            "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+            "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
             "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/runtime-corejs3": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz",
-            "integrity": "sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+            "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
             "dev": true,
             "requires": {
                 "core-js-pure": "^3.0.0",
@@ -1090,30 +1113,30 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-            "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+            "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
+                "@babel/generator": "^7.11.0",
                 "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.11.0",
+                "@babel/types": "^7.11.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "lodash": "^4.17.13"
+                "lodash": "^4.17.19"
             }
         },
         "@babel/types": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-            "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+            "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
             "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
+                "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -1189,15 +1212,16 @@
             "dev": true
         },
         "@jest/console": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
-            "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
+            "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
                 "chalk": "^4.0.0",
-                "jest-message-util": "^26.1.0",
-                "jest-util": "^26.1.0",
+                "jest-message-util": "^26.3.0",
+                "jest-util": "^26.3.0",
                 "slash": "^3.0.0"
             },
             "dependencies": {
@@ -1254,33 +1278,34 @@
             }
         },
         "@jest/core": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.1.0.tgz",
-            "integrity": "sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.0.tgz",
+            "integrity": "sha512-mpXm4OjWQbz7qbzGIiSqvfNZ1FxX6ywWgLtdSD2luPORt5zKPtqcdDnX7L8RdfMaj1znDBgN2+gB094ZIr7vnA==",
             "dev": true,
             "requires": {
-                "@jest/console": "^26.1.0",
-                "@jest/reporters": "^26.1.0",
-                "@jest/test-result": "^26.1.0",
-                "@jest/transform": "^26.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/console": "^26.3.0",
+                "@jest/reporters": "^26.4.0",
+                "@jest/test-result": "^26.3.0",
+                "@jest/transform": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.4",
-                "jest-changed-files": "^26.1.0",
-                "jest-config": "^26.1.0",
-                "jest-haste-map": "^26.1.0",
-                "jest-message-util": "^26.1.0",
+                "jest-changed-files": "^26.3.0",
+                "jest-config": "^26.4.0",
+                "jest-haste-map": "^26.3.0",
+                "jest-message-util": "^26.3.0",
                 "jest-regex-util": "^26.0.0",
-                "jest-resolve": "^26.1.0",
-                "jest-resolve-dependencies": "^26.1.0",
-                "jest-runner": "^26.1.0",
-                "jest-runtime": "^26.1.0",
-                "jest-snapshot": "^26.1.0",
-                "jest-util": "^26.1.0",
-                "jest-validate": "^26.1.0",
-                "jest-watcher": "^26.1.0",
+                "jest-resolve": "^26.4.0",
+                "jest-resolve-dependencies": "^26.4.0",
+                "jest-runner": "^26.4.0",
+                "jest-runtime": "^26.4.0",
+                "jest-snapshot": "^26.4.0",
+                "jest-util": "^26.3.0",
+                "jest-validate": "^26.4.0",
+                "jest-watcher": "^26.3.0",
                 "micromatch": "^4.0.2",
                 "p-each-series": "^2.1.0",
                 "rimraf": "^3.0.0",
@@ -1350,51 +1375,53 @@
             }
         },
         "@jest/environment": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
-            "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+            "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "^26.1.0",
-                "@jest/types": "^26.1.0",
-                "jest-mock": "^26.1.0"
+                "@jest/fake-timers": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
+                "jest-mock": "^26.3.0"
             }
         },
         "@jest/fake-timers": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
-            "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+            "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "@sinonjs/fake-timers": "^6.0.1",
-                "jest-message-util": "^26.1.0",
-                "jest-mock": "^26.1.0",
-                "jest-util": "^26.1.0"
+                "@types/node": "*",
+                "jest-message-util": "^26.3.0",
+                "jest-mock": "^26.3.0",
+                "jest-util": "^26.3.0"
             }
         },
         "@jest/globals": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.1.0.tgz",
-            "integrity": "sha512-MKiHPNaT+ZoG85oMaYUmGHEqu98y3WO2yeIDJrs2sJqHhYOy3Z6F7F/luzFomRQ8SQ1wEkmahFAz2291Iv8EAw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.0.tgz",
+            "integrity": "sha512-QKwoVAeL9d0xaEM9ebPvfc+bolN04F+o3zM2jswGDBiiNjCogZ3LvOaqumRdDyz6kLmbx+UhgMBAVuLunbXZ2A==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^26.1.0",
-                "@jest/types": "^26.1.0",
-                "expect": "^26.1.0"
+                "@jest/environment": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "expect": "^26.4.0"
             }
         },
         "@jest/reporters": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.1.0.tgz",
-            "integrity": "sha512-SVAysur9FOIojJbF4wLP0TybmqwDkdnFxHSPzHMMIYyBtldCW9gG+Q5xWjpMFyErDiwlRuPyMSJSU64A67Pazg==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.0.tgz",
+            "integrity": "sha512-14OPAAuYhgRBSNxAocVluX6ksdMdK/EuP9NmtBXU9g1uKaVBrPnohn/CVm6iMot1a9iU8BCxa5715YRf8FEg/A==",
             "dev": true,
             "requires": {
                 "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^26.1.0",
-                "@jest/test-result": "^26.1.0",
-                "@jest/transform": "^26.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/console": "^26.3.0",
+                "@jest/test-result": "^26.3.0",
+                "@jest/transform": "^26.3.0",
+                "@jest/types": "^26.3.0",
                 "chalk": "^4.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
@@ -1405,16 +1432,16 @@
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^4.0.0",
                 "istanbul-reports": "^3.0.2",
-                "jest-haste-map": "^26.1.0",
-                "jest-resolve": "^26.1.0",
-                "jest-util": "^26.1.0",
-                "jest-worker": "^26.1.0",
+                "jest-haste-map": "^26.3.0",
+                "jest-resolve": "^26.4.0",
+                "jest-util": "^26.3.0",
+                "jest-worker": "^26.3.0",
                 "node-notifier": "^7.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
                 "terminal-link": "^2.0.0",
-                "v8-to-istanbul": "^4.1.3"
+                "v8-to-istanbul": "^5.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1476,9 +1503,9 @@
             }
         },
         "@jest/source-map": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.1.0.tgz",
-            "integrity": "sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
+            "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0",
@@ -1495,46 +1522,46 @@
             }
         },
         "@jest/test-result": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
-            "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
+            "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
             "dev": true,
             "requires": {
-                "@jest/console": "^26.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/console": "^26.3.0",
+                "@jest/types": "^26.3.0",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "collect-v8-coverage": "^1.0.0"
             }
         },
         "@jest/test-sequencer": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.1.0.tgz",
-            "integrity": "sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.0.tgz",
+            "integrity": "sha512-9Z7lCShS7vERp+DRwIVNH/6sHMWwJK1DPnGCpGeVLGJJWJ4Y08sQI3vIKdmKHu2KmwlUBpRM+BFf7NlVUkl5XA==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^26.1.0",
+                "@jest/test-result": "^26.3.0",
                 "graceful-fs": "^4.2.4",
-                "jest-haste-map": "^26.1.0",
-                "jest-runner": "^26.1.0",
-                "jest-runtime": "^26.1.0"
+                "jest-haste-map": "^26.3.0",
+                "jest-runner": "^26.4.0",
+                "jest-runtime": "^26.4.0"
             }
         },
         "@jest/transform": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.1.0.tgz",
-            "integrity": "sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
+            "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "babel-plugin-istanbul": "^6.0.0",
                 "chalk": "^4.0.0",
                 "convert-source-map": "^1.4.0",
                 "fast-json-stable-stringify": "^2.0.0",
                 "graceful-fs": "^4.2.4",
-                "jest-haste-map": "^26.1.0",
+                "jest-haste-map": "^26.3.0",
                 "jest-regex-util": "^26.0.0",
-                "jest-util": "^26.1.0",
+                "jest-util": "^26.3.0",
                 "micromatch": "^4.0.2",
                 "pirates": "^4.0.1",
                 "slash": "^3.0.0",
@@ -1601,13 +1628,14 @@
             }
         },
         "@jest/types": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-            "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+            "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
                 "@types/yargs": "^15.0.0",
                 "chalk": "^4.0.0"
             },
@@ -1665,57 +1693,56 @@
             }
         },
         "@jitesoft/babel-preset-main": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@jitesoft/babel-preset-main/-/babel-preset-main-2.4.0.tgz",
-            "integrity": "sha512-YUTYi/L3dSvdfYbe1xHoEP1JcaqPWfq7Ki2ThA1ArfKga0YrXGictAvM5oGa9R/92xKLDPjJ+XhbObbivTgPsg==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@jitesoft/babel-preset-main/-/babel-preset-main-2.5.1.tgz",
+            "integrity": "sha512-w8KBj4khISF14zDX3yWKWHAm7wNwM5bSfHJD7dq2wjUYITYq5HIC/BiOFBkiXyji93pVx+Q3mia0BwLP7NIhIA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "7.10.4",
                 "@babel/plugin-proposal-class-properties": "7.10.4",
-                "@babel/plugin-proposal-decorators": "7.10.4",
+                "@babel/plugin-proposal-decorators": "7.10.5",
                 "@babel/plugin-proposal-export-default-from": "7.10.4",
-                "@babel/plugin-proposal-export-namespace-from": "7.10.4",
-                "@babel/plugin-proposal-partial-application": "7.10.4",
+                "@babel/plugin-proposal-partial-application": "7.10.5",
                 "@babel/plugin-proposal-private-methods": "7.10.4",
                 "@babel/plugin-proposal-throw-expressions": "7.10.4",
                 "@babel/plugin-transform-object-assign": "7.10.4",
-                "@babel/plugin-transform-runtime": "7.10.4",
-                "@babel/preset-env": "7.10.4",
-                "@babel/runtime-corejs3": "7.10.4"
+                "@babel/plugin-transform-runtime": "7.11.0",
+                "@babel/preset-env": "7.11.0",
+                "@babel/runtime-corejs3": "7.11.2"
             }
         },
         "@jitesoft/eslint-config": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@jitesoft/eslint-config/-/eslint-config-2.3.0.tgz",
-            "integrity": "sha512-Fk6C4dTUw/vaskzXyvT1Rxk9EhLV8q46QHBQX0WxFYUVt7whHpbdVb6W8EGygOsZxumOmPmmOKd+Kiq9SDY0FQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@jitesoft/eslint-config/-/eslint-config-2.5.0.tgz",
+            "integrity": "sha512-h6azHViS0+X4MOJBQ+agJwtwMNIa48av7963r7H4T3wKf72wjgVC6pAV3DtCP4XTbrGS9T1eGmu+gK2RhgewcQ==",
             "dev": true,
             "requires": {
                 "eslint-config-standard": "14.1.1",
                 "eslint-plugin-es": "3.0.1",
                 "eslint-plugin-import": "2.22.0",
-                "eslint-plugin-jest": "23.18.0",
+                "eslint-plugin-jest": "23.20.0",
                 "eslint-plugin-node": "11.1.0",
                 "eslint-plugin-promise": "4.2.1",
                 "eslint-plugin-standard": "4.0.1"
             }
         },
         "@jitesoft/events": {
-            "version": "1.3.24",
-            "resolved": "https://registry.npmjs.org/@jitesoft/events/-/events-1.3.24.tgz",
-            "integrity": "sha512-Oy3fufTeYY69OYCodR9E3qp5N0qztCof24lE+3j/M/Mm32DNPv9PH0ThtlxMIJ05E6/pyO4g6a3SoGrqJH6rLw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@jitesoft/events/-/events-2.0.0.tgz",
+            "integrity": "sha512-UKX9xMQTZxcqqpbrCdlAnO7NT1YUvALbHiEy9WLzJWYzs9UUcpEQ5hgcYCILooua0LfLB9OJJb2LkFyjoMr8Ig==",
             "requires": {
-                "@jitesoft/group-by": "^1.3.1"
+                "@jitesoft/group-by": "^1.3.3"
             }
         },
         "@jitesoft/group-by": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@jitesoft/group-by/-/group-by-1.3.1.tgz",
-            "integrity": "sha512-MRpKISygDB9KzEzCKWyCeJK+Gb8c7DvLryYMD9cFWSfAU1ZF3A5nH0+2DBY5gcHkR4duIqNz1sIgDCWZn28DLg=="
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@jitesoft/group-by/-/group-by-1.3.3.tgz",
+            "integrity": "sha512-8WgD/miycWzIdmBOCVxSsrYYHHQAmFjD9FZRlNf774WDtKz8q5x1Q2f+ttxgm4AJzOqk2xDH0eMXg/ZQahpZaw=="
         },
         "@jitesoft/sprintf": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/@jitesoft/sprintf/-/sprintf-1.0.15.tgz",
-            "integrity": "sha512-aCxoTLGssuyRHHamqTtRhFmp5sLtpXkc/aofjOw2pjhcM/xygfZkYZxmuU2xRoB1RR50/lL8/FZtE0emnMcPSw=="
+            "version": "1.0.18",
+            "resolved": "https://registry.npmjs.org/@jitesoft/sprintf/-/sprintf-1.0.18.tgz",
+            "integrity": "sha512-br7gKlUI/q7AvzoZFkaKtQQ64XeiNj9Nta8EOvbvdVzshlJoB556OEVEtEWMNJUJRnrSkrTpljZ0M3zB2PikAA=="
         },
         "@npmcli/move-file": {
             "version": "1.0.1",
@@ -1735,9 +1762,9 @@
             }
         },
         "@sinonjs/commons": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
-            "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+            "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
             "dev": true,
             "requires": {
                 "type-detect": "4.0.8"
@@ -1799,6 +1826,26 @@
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
         },
+        "@types/eslint": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.0.tgz",
+            "integrity": "sha512-LpUXkr7fnmPXWGxB0ZuLEzNeTURuHPavkC5zuU4sg62/TgL5ZEjamr5Y8b6AftwHtx2bPJasI+CL0TT2JwQ7aA==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "@types/eslint-scope": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
+            "integrity": "sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==",
+            "dev": true,
+            "requires": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
         "@types/estree": {
             "version": "0.0.45",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
@@ -1830,12 +1877,11 @@
             }
         },
         "@types/istanbul-reports": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-            "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+            "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "*",
                 "@types/istanbul-lib-report": "*"
             }
         },
@@ -1852,9 +1898,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.0.20",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.20.tgz",
-            "integrity": "sha512-MRn/NP3dee8yL5QhbSA6riuwkS+UOcsPUMOIOG3KMUQpuor/2TopdRBu8QaaB4fGU+gz/bzyDWt0FtUbeJ8H1A==",
+            "version": "14.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+            "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -2265,15 +2311,15 @@
             "dev": true
         },
         "abab": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-            "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
+            "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
             "dev": true
         },
         "acorn": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-            "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+            "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
             "dev": true
         },
         "acorn-globals": {
@@ -2480,9 +2526,9 @@
             "dev": true
         },
         "aws4": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-            "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+            "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
             "dev": true
         },
         "babel-eslint": {
@@ -2505,16 +2551,16 @@
             }
         },
         "babel-jest": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.1.0.tgz",
-            "integrity": "sha512-Nkqgtfe7j6PxLO6TnCQQlkMm8wdTdnIF8xrdpooHCuD5hXRzVEPbPneTJKknH5Dsv3L8ip9unHDAp48YQ54Dkg==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
+            "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
             "dev": true,
             "requires": {
-                "@jest/transform": "^26.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/transform": "^26.3.0",
+                "@jest/types": "^26.3.0",
                 "@types/babel__core": "^7.1.7",
                 "babel-plugin-istanbul": "^6.0.0",
-                "babel-preset-jest": "^26.1.0",
+                "babel-preset-jest": "^26.3.0",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
                 "slash": "^3.0.0"
@@ -2616,9 +2662,9 @@
             }
         },
         "babel-plugin-jest-hoist": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.1.0.tgz",
-            "integrity": "sha512-qhqLVkkSlqmC83bdMhM8WW4Z9tB+JkjqAqlbbohS9sJLT5Ha2vfzuKqg5yenXrAjOPG2YC0WiXdH3a9PvB+YYw==",
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+            "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.3.3",
@@ -2647,13 +2693,13 @@
             }
         },
         "babel-preset-jest": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.1.0.tgz",
-            "integrity": "sha512-na9qCqFksknlEj5iSdw1ehMVR06LCCTkZLGKeEtxDDdhg8xpUF09m29Kvh1pRbZ07h7AQ5ttLYUwpXL4tO6w7w==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
+            "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "^26.1.0",
-                "babel-preset-current-node-syntax": "^0.1.2"
+                "babel-plugin-jest-hoist": "^26.2.0",
+                "babel-preset-current-node-syntax": "^0.1.3"
             }
         },
         "balanced-match": {
@@ -2758,15 +2804,15 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
-            "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.0.tgz",
+            "integrity": "sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001093",
-                "electron-to-chromium": "^1.3.488",
-                "escalade": "^3.0.1",
-                "node-releases": "^1.1.58"
+                "caniuse-lite": "^1.0.30001111",
+                "electron-to-chromium": "^1.3.523",
+                "escalade": "^3.0.2",
+                "node-releases": "^1.1.60"
             }
         },
         "bser": {
@@ -2785,9 +2831,9 @@
             "dev": true
         },
         "cacache": {
-            "version": "15.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.4.tgz",
-            "integrity": "sha512-YlnKQqTbD/6iyoJvEY3KJftjrdBYroCbxxYXzhOzsFLWlp6KX4BOlEf4mTx0cMUfVaTS3ENL2QtDWeRYoGLkkw==",
+            "version": "15.0.5",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+            "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
             "dev": true,
             "requires": {
                 "@npmcli/move-file": "^1.0.1",
@@ -2795,7 +2841,7 @@
                 "fs-minipass": "^2.0.0",
                 "glob": "^7.1.4",
                 "infer-owner": "^1.0.4",
-                "lru-cache": "^5.1.1",
+                "lru-cache": "^6.0.0",
                 "minipass": "^3.1.1",
                 "minipass-collect": "^1.0.2",
                 "minipass-flush": "^1.0.5",
@@ -2856,9 +2902,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001097",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001097.tgz",
-            "integrity": "sha512-TeuSleKt/vWXaPkLVFqGDnbweYfq4IaZ6rUugFf3rWY6dlII8StUZ8Ddin0PkADfgYZ4wRqCdO2ORl4Rn5eZIA==",
+            "version": "1.0.30001115",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001115.tgz",
+            "integrity": "sha512-NZrG0439ePYna44lJX8evHX2L7Z3/z3qjVLnHgbBb/duNEnGo348u+BQS5o4HTWcrb++100dHFrU36IesIrC1Q==",
             "dev": true
         },
         "capture-exit": {
@@ -3258,17 +3304,6 @@
                 "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
-            },
-            "dependencies": {
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-                    "dev": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
-                }
             }
         },
         "cssom": {
@@ -3324,13 +3359,10 @@
             }
         },
         "decamelize": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-3.2.0.tgz",
-            "integrity": "sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==",
-            "dev": true,
-            "requires": {
-                "xregexp": "^4.2.4"
-            }
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decimal.js": {
             "version": "10.2.0",
@@ -3425,9 +3457,9 @@
             "dev": true
         },
         "diff-sequences": {
-            "version": "26.0.0",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
-            "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+            "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
             "dev": true
         },
         "doctrine": {
@@ -3468,9 +3500,15 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.496",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.496.tgz",
-            "integrity": "sha512-TXY4mwoyowwi4Lsrq9vcTUYBThyc1b2hXaTZI13p8/FRhY2CTaq5lK+DVjhYkKiTLsKt569Xes+0J5JsVXFurQ==",
+            "version": "1.3.534",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.534.tgz",
+            "integrity": "sha512-7x2S3yUrspNHQOoPk+Eo+iHViSiJiEGPI6BpmLy1eT2KRNGCkBt/NUYqjfXLd1DpDCQp7n3+LfA1RkbG+LqTZQ==",
+            "dev": true
+        },
+        "emittery": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+            "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -3495,9 +3533,9 @@
             }
         },
         "enhanced-resolve": {
-            "version": "5.0.0-beta.8",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.8.tgz",
-            "integrity": "sha512-6MteIR5h29V8UAsBVXkW7P2cAf+5p/c+Gu79xNCpBPt+hgKcJ0vujcX4vAiMGJjyq3SCHaY5N64C8HXwwRS3gQ==",
+            "version": "5.0.0-beta.10",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.10.tgz",
+            "integrity": "sha512-vEyxvHv3f8xl7i7QmTQ6BqKY32acSPQ4dTZo8WRMtcqTDYH9YyXnDxqXsQqBLvdRHUiwl9nVivESiM1RcrxbKQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.0",
@@ -3553,9 +3591,9 @@
             }
         },
         "escalade": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
-            "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
+            "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
             "dev": true
         },
         "escape-string-regexp": {
@@ -3626,9 +3664,9 @@
             }
         },
         "eslint": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.4.0.tgz",
-            "integrity": "sha512-gU+lxhlPHu45H3JkEGgYhWhkR9wLHHEXC9FbWFnTlEkbKyZKWgWRLgf61E8zWmBuI6g5xKBph9ltg3NtZMVF8g==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.7.0.tgz",
+            "integrity": "sha512-1KUxLzos0ZVsyL81PnRN335nDtQ8/vZUD6uMtWbF+5zDtjKcsklIi78XoE0MVL93QvWTu+E5y44VyyCsOMBrIg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -3639,9 +3677,9 @@
                 "doctrine": "^3.0.0",
                 "enquirer": "^2.3.5",
                 "eslint-scope": "^5.1.0",
-                "eslint-utils": "^2.0.0",
-                "eslint-visitor-keys": "^1.2.0",
-                "espree": "^7.1.0",
+                "eslint-utils": "^2.1.0",
+                "eslint-visitor-keys": "^1.3.0",
+                "espree": "^7.2.0",
                 "esquery": "^1.2.0",
                 "esutils": "^2.0.2",
                 "file-entry-cache": "^5.0.1",
@@ -3655,7 +3693,7 @@
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.14",
+                "lodash": "^4.17.19",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -3749,6 +3787,12 @@
                         "estraverse": "^4.1.1"
                     }
                 },
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                },
                 "globals": {
                     "version": "12.4.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -3804,6 +3848,15 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
+                    }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -3926,9 +3979,9 @@
             }
         },
         "eslint-plugin-jest": {
-            "version": "23.18.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.18.0.tgz",
-            "integrity": "sha512-wLPM/Rm1SGhxrFQ2TKM/BYsYPhn7ch6ZEK92S2o/vGkAAnDXM0I4nTIo745RIX+VlCRMFgBuJEax6XfTHMdeKg==",
+            "version": "23.20.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz",
+            "integrity": "sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==",
             "dev": true,
             "requires": {
                 "@typescript-eslint/experimental-utils": "^2.5.0"
@@ -3994,14 +4047,22 @@
             "dev": true
         },
         "espree": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
-            "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-7.2.0.tgz",
+            "integrity": "sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==",
             "dev": true,
             "requires": {
-                "acorn": "^7.2.0",
+                "acorn": "^7.3.1",
                 "acorn-jsx": "^5.2.0",
-                "eslint-visitor-keys": "^1.2.0"
+                "eslint-visitor-keys": "^1.3.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
             }
         },
         "esprima": {
@@ -4020,9 +4081,9 @@
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-                    "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
                     "dev": true
                 }
             }
@@ -4049,9 +4110,9 @@
             "dev": true
         },
         "events": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-            "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+            "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
             "dev": true
         },
         "exec-sh": {
@@ -4132,16 +4193,16 @@
             }
         },
         "expect": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-26.1.0.tgz",
-            "integrity": "sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.0.tgz",
+            "integrity": "sha512-dbYDJhFcqQsamlos6nEwAMe+ahdckJBk5fmw1DYGLQGabGSlUuT+Fm2jHYw5119zG3uIhP+lCQbjJhFEdZMJtg==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "ansi-styles": "^4.0.0",
-                "jest-get-type": "^26.0.0",
-                "jest-matcher-utils": "^26.1.0",
-                "jest-message-util": "^26.1.0",
+                "jest-get-type": "^26.3.0",
+                "jest-matcher-utils": "^26.4.0",
+                "jest-message-util": "^26.3.0",
                 "jest-regex-util": "^26.0.0"
             },
             "dependencies": {
@@ -4535,13 +4596,27 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "dev": true,
             "requires": {
-                "ajv": "^6.5.5",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.4",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+                    "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                }
             }
         },
         "has": {
@@ -4952,9 +5027,9 @@
             "dev": true
         },
         "is-regex": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-            "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+            "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
             "dev": true,
             "requires": {
                 "has-symbols": "^1.0.1"
@@ -5126,14 +5201,14 @@
             }
         },
         "jest": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-26.1.0.tgz",
-            "integrity": "sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.0.tgz",
+            "integrity": "sha512-lNCOS+ckRHE1wFyVtQClBmbsOVuH2GWUTJMDL3vunp9DXcah+V8vfvVVApngClcdoc3rgZpqOfCNKLjxjj2l4g==",
             "dev": true,
             "requires": {
-                "@jest/core": "^26.1.0",
+                "@jest/core": "^26.4.0",
                 "import-local": "^3.0.2",
-                "jest-cli": "^26.1.0"
+                "jest-cli": "^26.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5178,22 +5253,22 @@
                     "dev": true
                 },
                 "jest-cli": {
-                    "version": "26.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.1.0.tgz",
-                    "integrity": "sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==",
+                    "version": "26.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.0.tgz",
+                    "integrity": "sha512-kw2Pr3V2x9/WzSDGsbz/MJBNlCoPMxMudrIavft4bqRlv5tASjU51tyO+1Os1LdW2dAnLQZYsxFUZ8oWPyssGQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/core": "^26.1.0",
-                        "@jest/test-result": "^26.1.0",
-                        "@jest/types": "^26.1.0",
+                        "@jest/core": "^26.4.0",
+                        "@jest/test-result": "^26.3.0",
+                        "@jest/types": "^26.3.0",
                         "chalk": "^4.0.0",
                         "exit": "^0.1.2",
                         "graceful-fs": "^4.2.4",
                         "import-local": "^3.0.2",
                         "is-ci": "^2.0.0",
-                        "jest-config": "^26.1.0",
-                        "jest-util": "^26.1.0",
-                        "jest-validate": "^26.1.0",
+                        "jest-config": "^26.4.0",
+                        "jest-util": "^26.3.0",
+                        "jest-validate": "^26.4.0",
                         "prompts": "^2.0.1",
                         "yargs": "^15.3.1"
                     }
@@ -5210,12 +5285,12 @@
             }
         },
         "jest-changed-files": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.1.0.tgz",
-            "integrity": "sha512-HS5MIJp3B8t0NRKGMCZkcDUZo36mVRvrDETl81aqljT1S9tqiHRSpyoOvWg9ZilzZG9TDisDNaN1IXm54fLRZw==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
+            "integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "execa": "^4.0.0",
                 "throat": "^5.0.0"
             },
@@ -5292,33 +5367,42 @@
                     "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
                     "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
                     "dev": true
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
                 }
             }
         },
         "jest-config": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.1.0.tgz",
-            "integrity": "sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.0.tgz",
+            "integrity": "sha512-MxsvrBug8YY+C4QcUBtmgnHyFeW7w3Ouk/w9eplCDN8VJGVyBEZFe8Lxzfp2pSqh0Dqurqv8Oik2YkbekGUlxg==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/test-sequencer": "^26.1.0",
-                "@jest/types": "^26.1.0",
-                "babel-jest": "^26.1.0",
+                "@jest/test-sequencer": "^26.4.0",
+                "@jest/types": "^26.3.0",
+                "babel-jest": "^26.3.0",
                 "chalk": "^4.0.0",
                 "deepmerge": "^4.2.2",
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.2.4",
-                "jest-environment-jsdom": "^26.1.0",
-                "jest-environment-node": "^26.1.0",
-                "jest-get-type": "^26.0.0",
-                "jest-jasmine2": "^26.1.0",
+                "jest-environment-jsdom": "^26.3.0",
+                "jest-environment-node": "^26.3.0",
+                "jest-get-type": "^26.3.0",
+                "jest-jasmine2": "^26.4.0",
                 "jest-regex-util": "^26.0.0",
-                "jest-resolve": "^26.1.0",
-                "jest-util": "^26.1.0",
-                "jest-validate": "^26.1.0",
+                "jest-resolve": "^26.4.0",
+                "jest-util": "^26.3.0",
+                "jest-validate": "^26.4.0",
                 "micromatch": "^4.0.2",
-                "pretty-format": "^26.1.0"
+                "pretty-format": "^26.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5374,15 +5458,15 @@
             }
         },
         "jest-diff": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.1.0.tgz",
-            "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.0.tgz",
+            "integrity": "sha512-wwC38HlOW+iTq6j5tkj/ZamHn6/nrdcEOc/fKaVILNtN2NLWGdkfRaHWwfNYr5ehaLvuoG2LfCZIcWByVj0gjg==",
             "dev": true,
             "requires": {
                 "chalk": "^4.0.0",
-                "diff-sequences": "^26.0.0",
-                "jest-get-type": "^26.0.0",
-                "pretty-format": "^26.1.0"
+                "diff-sequences": "^26.3.0",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5447,16 +5531,16 @@
             }
         },
         "jest-each": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.1.0.tgz",
-            "integrity": "sha512-lYiSo4Igr81q6QRsVQq9LIkJW0hZcKxkIkHzNeTMPENYYDw/W/Raq28iJ0sLlNFYz2qxxeLnc5K2gQoFYlu2bA==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.0.tgz",
+            "integrity": "sha512-+cyBh1ehs6thVT/bsZVG+WwmRn2ix4Q4noS9yLZgM10yGWPW12/TDvwuOV2VZXn1gi09/ZwJKJWql6YW1C9zNw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "chalk": "^4.0.0",
-                "jest-get-type": "^26.0.0",
-                "jest-util": "^26.1.0",
-                "pretty-format": "^26.1.0"
+                "jest-get-type": "^26.3.0",
+                "jest-util": "^26.3.0",
+                "pretty-format": "^26.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5512,81 +5596,85 @@
             }
         },
         "jest-environment-jsdom": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.1.0.tgz",
-            "integrity": "sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
+            "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^26.1.0",
-                "@jest/fake-timers": "^26.1.0",
-                "@jest/types": "^26.1.0",
-                "jest-mock": "^26.1.0",
-                "jest-util": "^26.1.0",
+                "@jest/environment": "^26.3.0",
+                "@jest/fake-timers": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
+                "jest-mock": "^26.3.0",
+                "jest-util": "^26.3.0",
                 "jsdom": "^16.2.2"
             }
         },
         "jest-environment-node": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.1.0.tgz",
-            "integrity": "sha512-DNm5x1aQH0iRAe9UYAkZenuzuJ69VKzDCAYISFHQ5i9e+2Tbeu2ONGY7YStubCLH8a1wdKBgqScYw85+ySxqxg==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
+            "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^26.1.0",
-                "@jest/fake-timers": "^26.1.0",
-                "@jest/types": "^26.1.0",
-                "jest-mock": "^26.1.0",
-                "jest-util": "^26.1.0"
+                "@jest/environment": "^26.3.0",
+                "@jest/fake-timers": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
+                "jest-mock": "^26.3.0",
+                "jest-util": "^26.3.0"
             }
         },
         "jest-get-type": {
-            "version": "26.0.0",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-            "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+            "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
             "dev": true
         },
         "jest-haste-map": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.1.0.tgz",
-            "integrity": "sha512-WeBS54xCIz9twzkEdm6+vJBXgRBQfdbbXD0dk8lJh7gLihopABlJmIQFdWSDDtuDe4PRiObsjZSUjbJ1uhWEpA==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
+            "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "@types/graceful-fs": "^4.1.2",
+                "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
                 "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
-                "jest-serializer": "^26.1.0",
-                "jest-util": "^26.1.0",
-                "jest-worker": "^26.1.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-serializer": "^26.3.0",
+                "jest-util": "^26.3.0",
+                "jest-worker": "^26.3.0",
                 "micromatch": "^4.0.2",
                 "sane": "^4.0.3",
-                "walker": "^1.0.7",
-                "which": "^2.0.2"
+                "walker": "^1.0.7"
             }
         },
         "jest-jasmine2": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.1.0.tgz",
-            "integrity": "sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.0.tgz",
+            "integrity": "sha512-cGBxwzDDKB09EPJ4pE69BMDv+2lO442IB1xQd+vL3cua2OKdeXQK6iDlQKoRX/iP0RgU5T8sn9yahLcx/+ox8Q==",
             "dev": true,
             "requires": {
                 "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^26.1.0",
-                "@jest/source-map": "^26.1.0",
-                "@jest/test-result": "^26.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/environment": "^26.3.0",
+                "@jest/source-map": "^26.3.0",
+                "@jest/test-result": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
                 "chalk": "^4.0.0",
                 "co": "^4.6.0",
-                "expect": "^26.1.0",
+                "expect": "^26.4.0",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^26.1.0",
-                "jest-matcher-utils": "^26.1.0",
-                "jest-message-util": "^26.1.0",
-                "jest-runtime": "^26.1.0",
-                "jest-snapshot": "^26.1.0",
-                "jest-util": "^26.1.0",
-                "pretty-format": "^26.1.0",
+                "jest-each": "^26.4.0",
+                "jest-matcher-utils": "^26.4.0",
+                "jest-message-util": "^26.3.0",
+                "jest-runtime": "^26.4.0",
+                "jest-snapshot": "^26.4.0",
+                "jest-util": "^26.3.0",
+                "pretty-format": "^26.4.0",
                 "throat": "^5.0.0"
             },
             "dependencies": {
@@ -5643,25 +5731,25 @@
             }
         },
         "jest-leak-detector": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.1.0.tgz",
-            "integrity": "sha512-dsMnKF+4BVOZwvQDlgn3MG+Ns4JuLv8jNvXH56bgqrrboyCbI1rQg6EI5rs+8IYagVcfVP2yZFKfWNZy0rK0Hw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.0.tgz",
+            "integrity": "sha512-7EXKKEKnAWUPyiVtGZzJflbPOtYUdlNoevNVOkAcPpdR8xWiYKPGNGA6sz25S+8YhZq3rmkQJYAh3/P0VnoRwA==",
             "dev": true,
             "requires": {
-                "jest-get-type": "^26.0.0",
-                "pretty-format": "^26.1.0"
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.4.0"
             }
         },
         "jest-matcher-utils": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.1.0.tgz",
-            "integrity": "sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.0.tgz",
+            "integrity": "sha512-u+xdCdq+F262DH+PutJKXLGr2H5P3DImdJCir51PGSfi3TtbLQ5tbzKaN8BkXbiTIU6ayuAYBWTlU1nyckVdzA==",
             "dev": true,
             "requires": {
                 "chalk": "^4.0.0",
-                "jest-diff": "^26.1.0",
-                "jest-get-type": "^26.0.0",
-                "pretty-format": "^26.1.0"
+                "jest-diff": "^26.4.0",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5717,13 +5805,13 @@
             }
         },
         "jest-message-util": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.1.0.tgz",
-            "integrity": "sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+            "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "@types/stack-utils": "^1.0.1",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
@@ -5785,12 +5873,13 @@
             }
         },
         "jest-mock": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.1.0.tgz",
-            "integrity": "sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+            "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0"
+                "@jest/types": "^26.3.0",
+                "@types/node": "*"
             }
         },
         "jest-pnp-resolver": {
@@ -5806,16 +5895,16 @@
             "dev": true
         },
         "jest-resolve": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.1.0.tgz",
-            "integrity": "sha512-KsY1JV9FeVgEmwIISbZZN83RNGJ1CC+XUCikf/ZWJBX/tO4a4NvA21YixokhdR9UnmPKKAC4LafVixJBrwlmfg==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
+            "integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
-                "jest-pnp-resolver": "^1.2.1",
-                "jest-util": "^26.1.0",
+                "jest-pnp-resolver": "^1.2.2",
+                "jest-util": "^26.3.0",
                 "read-pkg-up": "^7.0.1",
                 "resolve": "^1.17.0",
                 "slash": "^3.0.0"
@@ -5891,9 +5980,9 @@
                     }
                 },
                 "parse-json": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-                    "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+                    "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
                     "dev": true,
                     "requires": {
                         "@babel/code-frame": "^7.0.0",
@@ -5960,39 +6049,40 @@
             }
         },
         "jest-resolve-dependencies": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.1.0.tgz",
-            "integrity": "sha512-fQVEPHHQ1JjHRDxzlLU/buuQ9om+hqW6Vo928aa4b4yvq4ZHBtRSDsLdKQLuCqn5CkTVpYZ7ARh2fbA8WkRE6g==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.0.tgz",
+            "integrity": "sha512-hznK/hlrlhu8hwdbieRdHFKmcV83GW8t30libt/v6j1L3IEzb8iN21SaWzV8KRAAK4ijiU0kuge0wnHn+0rytQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "jest-regex-util": "^26.0.0",
-                "jest-snapshot": "^26.1.0"
+                "jest-snapshot": "^26.4.0"
             }
         },
         "jest-runner": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.1.0.tgz",
-            "integrity": "sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.0.tgz",
+            "integrity": "sha512-XF+tnUGolnPriu6Gg+HHWftspMjD5NkTV2mQppQnpZe39GcUangJ0al7aBGtA3GbVAcRd048DQiJPmsQRdugjw==",
             "dev": true,
             "requires": {
-                "@jest/console": "^26.1.0",
-                "@jest/environment": "^26.1.0",
-                "@jest/test-result": "^26.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/console": "^26.3.0",
+                "@jest/environment": "^26.3.0",
+                "@jest/test-result": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
                 "chalk": "^4.0.0",
+                "emittery": "^0.7.1",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.4",
-                "jest-config": "^26.1.0",
+                "jest-config": "^26.4.0",
                 "jest-docblock": "^26.0.0",
-                "jest-haste-map": "^26.1.0",
-                "jest-jasmine2": "^26.1.0",
-                "jest-leak-detector": "^26.1.0",
-                "jest-message-util": "^26.1.0",
-                "jest-resolve": "^26.1.0",
-                "jest-runtime": "^26.1.0",
-                "jest-util": "^26.1.0",
-                "jest-worker": "^26.1.0",
+                "jest-haste-map": "^26.3.0",
+                "jest-leak-detector": "^26.4.0",
+                "jest-message-util": "^26.3.0",
+                "jest-resolve": "^26.4.0",
+                "jest-runtime": "^26.4.0",
+                "jest-util": "^26.3.0",
+                "jest-worker": "^26.3.0",
                 "source-map-support": "^0.5.6",
                 "throat": "^5.0.0"
             },
@@ -6050,34 +6140,34 @@
             }
         },
         "jest-runtime": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.1.0.tgz",
-            "integrity": "sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.0.tgz",
+            "integrity": "sha512-1fjZgGpkyQBUTo59Vi19I4IcsBwzY6uwVFNjUmR06iIi3XRErkY28yimi4IUDRrofQErqcDEw2n3DF9WmQ6vEg==",
             "dev": true,
             "requires": {
-                "@jest/console": "^26.1.0",
-                "@jest/environment": "^26.1.0",
-                "@jest/fake-timers": "^26.1.0",
-                "@jest/globals": "^26.1.0",
-                "@jest/source-map": "^26.1.0",
-                "@jest/test-result": "^26.1.0",
-                "@jest/transform": "^26.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/console": "^26.3.0",
+                "@jest/environment": "^26.3.0",
+                "@jest/fake-timers": "^26.3.0",
+                "@jest/globals": "^26.4.0",
+                "@jest/source-map": "^26.3.0",
+                "@jest/test-result": "^26.3.0",
+                "@jest/transform": "^26.3.0",
+                "@jest/types": "^26.3.0",
                 "@types/yargs": "^15.0.0",
                 "chalk": "^4.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.4",
-                "jest-config": "^26.1.0",
-                "jest-haste-map": "^26.1.0",
-                "jest-message-util": "^26.1.0",
-                "jest-mock": "^26.1.0",
+                "jest-config": "^26.4.0",
+                "jest-haste-map": "^26.3.0",
+                "jest-message-util": "^26.3.0",
+                "jest-mock": "^26.3.0",
                 "jest-regex-util": "^26.0.0",
-                "jest-resolve": "^26.1.0",
-                "jest-snapshot": "^26.1.0",
-                "jest-util": "^26.1.0",
-                "jest-validate": "^26.1.0",
+                "jest-resolve": "^26.4.0",
+                "jest-snapshot": "^26.4.0",
+                "jest-util": "^26.3.0",
+                "jest-validate": "^26.4.0",
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0",
                 "yargs": "^15.3.1"
@@ -6142,34 +6232,35 @@
             }
         },
         "jest-serializer": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.1.0.tgz",
-            "integrity": "sha512-eqZOQG/0+MHmr25b2Z86g7+Kzd5dG9dhCiUoyUNJPgiqi38DqbDEOlHcNijyfZoj74soGBohKBZuJFS18YTJ5w==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
+            "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
             "dev": true,
             "requires": {
+                "@types/node": "*",
                 "graceful-fs": "^4.2.4"
             }
         },
         "jest-snapshot": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.1.0.tgz",
-            "integrity": "sha512-YhSbU7eMTVQO/iRbNs8j0mKRxGp4plo7sJ3GzOQ0IYjvsBiwg0T1o0zGQAYepza7lYHuPTrG5J2yDd0CE2YxSw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.0.tgz",
+            "integrity": "sha512-vFGmNGWHMBomrlOpheTMoqihymovuH3GqfmaEIWoPpsxUXyxT3IlbxI5I4m2vg0uv3HUJYg5JoGrkgMzVsAwCg==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0",
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "@types/prettier": "^2.0.0",
                 "chalk": "^4.0.0",
-                "expect": "^26.1.0",
+                "expect": "^26.4.0",
                 "graceful-fs": "^4.2.4",
-                "jest-diff": "^26.1.0",
-                "jest-get-type": "^26.0.0",
-                "jest-haste-map": "^26.1.0",
-                "jest-matcher-utils": "^26.1.0",
-                "jest-message-util": "^26.1.0",
-                "jest-resolve": "^26.1.0",
+                "jest-diff": "^26.4.0",
+                "jest-get-type": "^26.3.0",
+                "jest-haste-map": "^26.3.0",
+                "jest-matcher-utils": "^26.4.0",
+                "jest-message-util": "^26.3.0",
+                "jest-resolve": "^26.4.0",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^26.1.0",
+                "pretty-format": "^26.4.0",
                 "semver": "^7.3.2"
             },
             "dependencies": {
@@ -6232,12 +6323,13 @@
             }
         },
         "jest-util": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.1.0.tgz",
-            "integrity": "sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+            "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
                 "is-ci": "^2.0.0",
@@ -6297,17 +6389,17 @@
             }
         },
         "jest-validate": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.1.0.tgz",
-            "integrity": "sha512-WPApOOnXsiwhZtmkDsxnpye+XLb/tUISP+H6cHjfUIXvlG+eKwP+isnivsxlHCPaO9Q5wvbhloIBkdF3qUn+Nw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.0.tgz",
+            "integrity": "sha512-t56Z/FRMrLP6mpmje7/YgHy0wOzcuc6i3LBXz6kjmsUWYN62OuMdC86Vg9/dX59SvyitSqqegOrx+h7BkNXeaQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "camelcase": "^6.0.0",
                 "chalk": "^4.0.0",
-                "jest-get-type": "^26.0.0",
+                "jest-get-type": "^26.3.0",
                 "leven": "^3.1.0",
-                "pretty-format": "^26.1.0"
+                "pretty-format": "^26.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6369,16 +6461,17 @@
             }
         },
         "jest-watcher": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.1.0.tgz",
-            "integrity": "sha512-ffEOhJl2EvAIki613oPsSG11usqnGUzIiK7MMX6hE4422aXOcVEG3ySCTDFLn1+LZNXGPE8tuJxhp8OBJ1pgzQ==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
+            "integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^26.1.0",
-                "@jest/types": "^26.1.0",
+                "@jest/test-result": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
-                "jest-util": "^26.1.0",
+                "jest-util": "^26.3.0",
                 "string-length": "^4.0.1"
             },
             "dependencies": {
@@ -6435,11 +6528,12 @@
             }
         },
         "jest-worker": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
-            "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+            "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
             "dev": true,
             "requires": {
+                "@types/node": "*",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^7.0.0"
             },
@@ -6484,9 +6578,9 @@
             "dev": true
         },
         "jsdom": {
-            "version": "16.3.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.3.0.tgz",
-            "integrity": "sha512-zggeX5UuEknpdZzv15+MS1dPYG0J/TftiiNunOeNxSl3qr8Z6cIlQpN0IdJa44z9aFxZRIVqRncvEhQ7X5DtZg==",
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+            "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
             "dev": true,
             "requires": {
                 "abab": "^2.0.3",
@@ -6701,20 +6795,12 @@
             }
         },
         "lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
             "requires": {
-                "yallist": "^3.0.2"
-            },
-            "dependencies": {
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-                    "dev": true
-                }
+                "yallist": "^4.0.0"
             }
         },
         "make-dir": {
@@ -6839,18 +6925,18 @@
             }
         },
         "minipass-pipeline": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.3.tgz",
-            "integrity": "sha512-cFOknTvng5vqnwOpDsZTWhNll6Jf8o2x+/diplafmxpuIymAjzoOolZG0VvQf3V2HgqzJNhnuKHYp2BqDgz8IQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
             "dev": true,
             "requires": {
                 "minipass": "^3.0.0"
             }
         },
         "minizlib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
-            "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
             "dev": true,
             "requires": {
                 "minipass": "^3.0.0",
@@ -6949,17 +7035,17 @@
             "dev": true
         },
         "node-notifier": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.1.tgz",
-            "integrity": "sha512-VkzhierE7DBmQEElhTGJIoiZa1oqRijOtgOlsXg32KrJRXsPy0NXFBqWGW/wTswnJlDCs5viRYaqWguqzsKcmg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.2.tgz",
+            "integrity": "sha512-ux+n4hPVETuTL8+daJXTOC6uKLgMsl1RYfFv7DKRzyvzBapqco0rZZ9g72ZN8VS6V+gvNYHYa/ofcCY8fkJWsA==",
             "dev": true,
             "optional": true,
             "requires": {
                 "growly": "^1.3.0",
-                "is-wsl": "^2.1.1",
-                "semver": "^7.2.1",
+                "is-wsl": "^2.2.0",
+                "semver": "^7.3.2",
                 "shellwords": "^0.1.1",
-                "uuid": "^7.0.3",
+                "uuid": "^8.2.0",
                 "which": "^2.0.2"
             },
             "dependencies": {
@@ -6969,13 +7055,23 @@
                     "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
                     "dev": true,
                     "optional": true
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
                 }
             }
         },
         "node-releases": {
-            "version": "1.1.59",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
-            "integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==",
+            "version": "1.1.60",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
+            "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
             "dev": true
         },
         "normalize-package-data": {
@@ -7342,12 +7438,12 @@
             "dev": true
         },
         "pretty-format": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-            "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
+            "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.1.0",
+                "@jest/types": "^26.3.0",
                 "ansi-regex": "^5.0.0",
                 "ansi-styles": "^4.0.0",
                 "react-is": "^16.12.0"
@@ -7542,9 +7638,9 @@
             }
         },
         "regenerator-runtime": {
-            "version": "0.13.5",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+            "version": "0.13.7",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+            "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
             "dev": true
         },
         "regenerator-transform": {
@@ -7674,21 +7770,21 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-            "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.15"
+                "lodash": "^4.17.19"
             }
         },
         "request-promise-native": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-            "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
             "dev": true,
             "requires": {
-                "request-promise-core": "1.1.3",
+                "request-promise-core": "1.1.4",
                 "stealthy-require": "^1.1.1",
                 "tough-cookie": "^2.3.3"
             },
@@ -8418,9 +8514,9 @@
             "dev": true
         },
         "strip-json-comments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-            "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
         "supports-color": {
@@ -8510,15 +8606,15 @@
             "dev": true
         },
         "tar": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
-            "integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+            "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
             "dev": true,
             "requires": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
                 "minipass": "^3.0.0",
-                "minizlib": "^2.1.0",
+                "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
             },
@@ -8561,15 +8657,15 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.0.6.tgz",
-            "integrity": "sha512-z3HLOOPUHkCNGkeEHqqiMAIy1pjpHwS1o+i6Zn0Ws3EAvHJj46737efNNEvJ0Vx9BdDQM83d56qySDJOSORA0A==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.1.0.tgz",
+            "integrity": "sha512-cjdZte66fYkZ65rQ2oJfrdCAkkhJA7YLYk5eGOcGCSGlq0ieZupRdjedSQXYknMPo2IveQL+tPdrxUkERENCFA==",
             "dev": true,
             "requires": {
-                "cacache": "^15.0.4",
+                "cacache": "^15.0.5",
                 "find-cache-dir": "^3.3.1",
-                "jest-worker": "^26.0.0",
-                "p-limit": "^3.0.1",
+                "jest-worker": "^26.2.1",
+                "p-limit": "^3.0.2",
                 "schema-utils": "^2.6.6",
                 "serialize-javascript": "^4.0.0",
                 "source-map": "^0.6.1",
@@ -8578,9 +8674,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "6.12.3",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-                    "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+                    "version": "6.12.4",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+                    "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -8629,9 +8725,9 @@
                     }
                 },
                 "p-limit": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
-                    "integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+                    "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -9012,9 +9108,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
             "dev": true,
             "optional": true
         },
@@ -9025,9 +9121,9 @@
             "dev": true
         },
         "v8-to-istanbul": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
-            "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
+            "integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -9092,9 +9188,9 @@
             }
         },
         "watchpack": {
-            "version": "2.0.0-beta.13",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.0.0-beta.13.tgz",
-            "integrity": "sha512-ZEFq2mx/k5qgQwgi6NOm+2ImICb8ngAkA/rZ6oyXZ7SgPn3pncf+nfhYTCrs3lmHwOxnPtGLTOuFLfpSMh1VMA==",
+            "version": "2.0.0-beta.14",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.0.0-beta.14.tgz",
+            "integrity": "sha512-mToSRWik+KvbvQ0c9Oxy2PjhiCUz5CXx6kpKI9MdJ/fiBDxi0HYx4UTGxQoHIEA7aXQKJrfNUhw9OeH2bc4Wvg==",
             "dev": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
@@ -9108,35 +9204,59 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.0.0-beta.22",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.0.0-beta.22.tgz",
-            "integrity": "sha512-t3HnQPy88PASM2ur0rvUXau8vAz287BlH8DpiaHoWkjlLThLx7olzExtTsVJEFen/9uTfWOV21dWS8kiYmGLkA==",
+            "version": "5.0.0-beta.26",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.0.0-beta.26.tgz",
+            "integrity": "sha512-/T4eA+MxVf6AzEU6V9PMUM6m+ChNlZfXtd5hHVKgjyyWv+XurGAihQsxaK4alILEBArWLgeDwi8IKwNur1t1vw==",
             "dev": true,
             "requires": {
+                "@types/eslint-scope": "^3.7.0",
                 "@types/estree": "^0.0.45",
                 "@webassemblyjs/ast": "1.9.0",
                 "@webassemblyjs/helper-module-context": "1.9.0",
                 "@webassemblyjs/wasm-edit": "1.9.0",
                 "@webassemblyjs/wasm-parser": "1.9.0",
-                "acorn": "^7.3.0",
+                "acorn": "^7.4.0",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "5.0.0-beta.8",
-                "eslint-scope": "^5.0.0",
-                "events": "^3.0.0",
+                "core-js": "^3.6.5",
+                "enhanced-resolve": "5.0.0-beta.10",
+                "eslint-scope": "^5.1.0",
+                "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.1.15",
+                "graceful-fs": "^4.2.4",
                 "json-parse-better-errors": "^1.0.2",
                 "loader-runner": "^4.0.0",
-                "mime-types": "^2.1.26",
-                "neo-async": "^2.6.1",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
                 "pkg-dir": "^4.2.0",
-                "schema-utils": "^2.5.0",
-                "tapable": "^2.0.0-beta.10",
+                "schema-utils": "^2.7.0",
+                "tapable": "^2.0.0-beta.11",
                 "terser-webpack-plugin": "^3.0.2",
-                "watchpack": "2.0.0-beta.13",
+                "watchpack": "2.0.0-beta.14",
                 "webpack-sources": "2.0.0-beta.8"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.4",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+                    "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "eslint-scope": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+                    "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
                 "find-up": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -9178,6 +9298,17 @@
                     "dev": true,
                     "requires": {
                         "find-up": "^4.0.0"
+                    }
+                },
+                "schema-utils": {
+                    "version": "2.7.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+                    "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.4",
+                        "ajv": "^6.12.2",
+                        "ajv-keywords": "^3.4.1"
                     }
                 }
             }
@@ -9419,9 +9550,9 @@
             }
         },
         "which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
@@ -9563,15 +9694,6 @@
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
         },
-        "xregexp": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
-            "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime-corejs3": "^7.8.3"
-            }
-        },
         "y18n": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -9585,13 +9707,13 @@
             "dev": true
         },
         "yargs": {
-            "version": "15.4.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.0.tgz",
-            "integrity": "sha512-D3fRFnZwLWp8jVAAhPZBsmeIHY8tTsb8ItV9KaAaopmC6wde2u6Yw29JBIZHXw14kgkRnYmDgmQU4FVMDlIsWw==",
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
             "dev": true,
             "requires": {
                 "cliui": "^6.0.0",
-                "decamelize": "^3.2.0",
+                "decamelize": "^1.2.0",
                 "find-up": "^4.1.0",
                 "get-caller-file": "^2.0.1",
                 "require-directory": "^2.1.1",
@@ -9670,14 +9792,6 @@
             "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
-            },
-            "dependencies": {
-                "decamelize": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-                    "dev": true
-                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -47,21 +47,21 @@
         ]
     },
     "dependencies": {
-        "@jitesoft/events": "^1.3.24",
-        "@jitesoft/sprintf": "^1.0.15"
+        "@jitesoft/events": "^2.0.0",
+        "@jitesoft/sprintf": "^1.0.18"
     },
     "devDependencies": {
-        "@babel/core": "^7.10.4",
-        "@jitesoft/babel-preset-main": "^2.4.0",
-        "@jitesoft/eslint-config": "^2.3.0",
+        "@babel/core": "^7.11.1",
+        "@jitesoft/babel-preset-main": "^2.5.1",
+        "@jitesoft/eslint-config": "^2.5.0",
         "babel-eslint": "^11.0.0-beta.2",
-        "babel-jest": "^26.1.0",
+        "babel-jest": "^26.3.0",
         "babel-loader": "^8.1.0",
         "core-js": "^3.6.5",
         "cross-env": "^7.0.2",
-        "eslint": "^7.4.0",
-        "jest": "^26.1.0",
-        "webpack": "^5.0.0-beta.22",
+        "eslint": "^7.7.0",
+        "jest": "^26.4.0",
+        "webpack": "^5.0.0-beta.26",
         "webpack-cli": "^4.0.0-beta.8"
     },
     "scripts": {

--- a/src/Yolog.js
+++ b/src/Yolog.js
@@ -267,7 +267,7 @@ export default class Yolog {
     });
 
     // Fire the events without waiting on the promises to resolve.
-    this.#eventHandler.emitAsync(tag, new Event({
+    this.#eventHandler.emit(tag, new Event({
       message: message,
       arguments: args,
       timestamp: time,


### PR DESCRIPTION
Dependency updates.

This PR increases the version of the `@jitesoft/events` package to 2.0.0, which removed a deprecated function. Hence a minor version bump is a good idea.